### PR TITLE
Fix requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,8 @@ IP infos are written to `testres01`
 ## Requirements
 python3
 ```
-glob
 maxminddb
 geoip2
 pyasn
 pandas
-pathlib 
-functools
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-glob2
 maxminddb
 geoip2
 pyasn
 pandas
-pathlib 


### PR DESCRIPTION
While `glob2` is given as a requirement, `glob` is used (which [is part of the python standard library](https://docs.python.org/3/library/glob.html). `pathlib` [is part of the python standard library since python 3.4](https://docs.python.org/3/library/pathlib.html), which is [EoL since 2019](https://www.python.org/downloads/release/python-3410/). `functools` is listed as a dependency in the README, but not listed in `requirements.txt` (and is also part of the standard library)